### PR TITLE
Add CI Pipeline for iOS Build and Test  

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - develop
 
 jobs:
   build-and-test:
@@ -23,11 +26,8 @@ jobs:
           scheme: EPCollaboratif
           destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
           action: test
-          result-bundle-path: TestResults/TestResults.xcresult
+          result-bundle-path: 'TestResults/TestResults.xcresult'
       
-      - name: List TestResults Directory
-        run: ls -R TestResults
-
       - name: Process Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
           scheme: EPCollaboratif
           destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
           action: test
-          result-bundle-path: './TestResults/TestResults.xcresult'
-
-      - name: Verify TestResults Directory
+          result-bundle-path: TestResults/TestResults.xcresult
+      
+      - name: List TestResults Directory
         run: ls -R TestResults
 
       - name: Process Test Results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: kishikawakatsumi/xcresulttool@v1
         with:
           path: ./TestResults/TestResults.xcresult
-          upload-artifact: false
+          upload-bundles: 'never'
         if: always()
 
       - name: Upload Test Results Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
           echo "List des fichiers dans TestResults"
           ls -R TestResults   # Affiche récursivement le contenu du dossier pour vérifier s'il y a bien des résultats générés
 
+      - name: Upload Test Results as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: TestResults
+          
       - name: Process Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4  # Mise à jour vers v4
 
       - name: Build and Test
         uses: sersoft-gmbh/xcodebuild-action@v3.2.0
@@ -28,10 +28,18 @@ jobs:
           ls -la .
           echo "Listing files in TestResults directory:"
           ls -la TestResults || echo "TestResults directory not found"
-        if: always()  # Exécute cette étape même en cas d'échec
+        if: always()
 
       - name: Process Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:
+          path: ./TestResults/TestResults.xcresult
+          upload-artifact: false
+        if: always()
+
+      - name: Upload Test Results Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
           path: ./TestResults/TestResults.xcresult
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: iOS Build and Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+
+  steps:
+    - name: Checkout repository
+        uses: actions/checkout@v2
+
+    - name: Build and Test
+        uses: sersoft-gmbh/xcodebuild-action@v3.2.0
+        with:
+            project: EPCollaboratif.xcodeproj
+            scheme: EPCollaboratif
+            destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
+            action: test
+            result-bundle-path: 'TestResults/TestResults.xcresult'
+
+    - name: Process Test Results
+        uses: kishikawakatsumi/xcresulttool@v1
+        with:
+            path: TestResults/TestResults.xcresult
+            if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,21 @@ jobs:
   build-and-test:
     runs-on: macos-latest
 
-  steps:
-    - name: Checkout repository
+    steps:
+      - name: Checkout repository
         uses: actions/checkout@v2
 
-    - name: Build and Test
+      - name: Build and Test
         uses: sersoft-gmbh/xcodebuild-action@v3.2.0
         with:
-            project: EPCollaboratif.xcodeproj
-            scheme: EPCollaboratif
-            destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
-            action: test
-            result-bundle-path: 'TestResults/TestResults.xcresult'
+          project: EPCollaboratif.xcodeproj
+          scheme: EPCollaboratif
+          destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
+          action: test
+          result-bundle-path: 'TestResults/TestResults.xcresult'
 
-    - name: Process Test Results
+      - name: Process Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-            path: TestResults/TestResults.xcresult
-            if: success() || failure()
+          path: TestResults/TestResults.xcresult
+        if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Create TestResults Directory
-        run: mkdir -p TestResults
-
       - name: Build and Test
         uses: sersoft-gmbh/xcodebuild-action@v3.2.0
         with:
@@ -27,7 +24,12 @@ jobs:
           destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
           action: test
           result-bundle-path: 'TestResults/TestResults.xcresult'
-      
+
+      - name: List generated files
+        run: |
+          echo "List des fichiers dans TestResults"
+          ls -R TestResults   # Affiche récursivement le contenu du dossier pour vérifier s'il y a bien des résultats générés
+
       - name: Process Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,11 @@ jobs:
           scheme: EPCollaboratif
           destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
           action: test
-          result-bundle-path: 'TestResults/TestResults.xcresult'
-
+          result-bundle-path: 'TestResults'
+      
       - name: Process Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-          path: TestResults/TestResults.xcresult
+          path: TestResults
         if: success() || failure()
+      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Create TestResults Directory
+        run: mkdir -p TestResults
+
       - name: Build and Test
         uses: sersoft-gmbh/xcodebuild-action@v3.2.0
         with:
@@ -20,11 +23,13 @@ jobs:
           scheme: EPCollaboratif
           destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
           action: test
-          result-bundle-path: 'TestResults'
-      
+          result-bundle-path: './TestResults/TestResults.xcresult'
+
+      - name: Verify TestResults Directory
+        run: ls -R TestResults
+
       - name: Process Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-          path: TestResults
+          path: TestResults/TestResults.xcresult
         if: success() || failure()
-      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - develop
 
 jobs:
   build-and-test:
@@ -23,21 +20,18 @@ jobs:
           scheme: EPCollaboratif
           destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
           action: test
-          result-bundle-path: 'TestResults/TestResults.xcresult'
+          result-bundle-path: './TestResults/TestResults.xcresult'
 
-      - name: List generated files
+      - name: Debug - List files in TestResults directory
         run: |
-          echo "List des fichiers dans TestResults"
-          ls -R TestResults   # Affiche récursivement le contenu du dossier pour vérifier s'il y a bien des résultats générés
+          echo "Listing files in the workspace:"
+          ls -la .
+          echo "Listing files in TestResults directory:"
+          ls -la TestResults || echo "TestResults directory not found"
+        if: always()  # Exécute cette étape même en cas d'échec
 
-      - name: Upload Test Results as Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-results
-          path: TestResults
-          
       - name: Process Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-          path: TestResults/TestResults.xcresult
-        if: success() || failure()
+          path: ./TestResults/TestResults.xcresult
+        if: always()


### PR DESCRIPTION
### Pull Request: Add CI Pipeline for iOS Build and Test  

#### Description  
This pull request sets up a CI pipeline using **GitHub Actions** to build and test the iOS app automatically for every pull request made to the `main` branch.  

#### Changes Made  
- Created `.github/workflows/ci.yml` to define the CI process.  
- Triggered by pull requests targeting `main`.  
- Workflow runs on macOS.  

#### Workflow Steps  
1. **Checkout Code:** Uses `actions/checkout@v2`.  
2. **Build and Test:** Uses `sersoft-gmbh/xcodebuild-action@v3.2.0` to build and test the app.  
3. **Process Test Results:** Uses `kishikawakatsumi/xcresulttool@v1` to generate test reports.  

The CI pipeline ensures code quality and stability before merging.